### PR TITLE
find all activities for graph panel

### DIFF
--- a/src/main/java/net/inpercima/runandfun/service/ActivityRepository.java
+++ b/src/main/java/net/inpercima/runandfun/service/ActivityRepository.java
@@ -2,10 +2,16 @@ package net.inpercima.runandfun.service;
 
 import net.inpercima.runandfun.model.Activity;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ActivityRepository extends ElasticsearchRepository<Activity, String> {
+
+    Page<Activity> findAllByTypeOrderByDateDesc(String type, Pageable pageable);
+
+    int countByType(String type);
 
 }

--- a/src/main/java/net/inpercima/runandfun/service/RunAndFunService.java
+++ b/src/main/java/net/inpercima/runandfun/service/RunAndFunService.java
@@ -24,8 +24,10 @@ public interface RunAndFunService {
 
     void indexActivities(String accessToken);
 
-    Page<Activity> listActivities(Pageable pageable, String type, LocalDate minDate, LocalDate maxDate,
-            Float minDistance, Float maxDistance, String query);
+    Page<Activity> listAllActivitiesByType(String type);
+
+    Page<Activity> listActivities(Pageable pageable, String type, LocalDate minDate, LocalDate maxDate, Float minDistance,
+            Float maxDistance, String query);
 
     AppState getAppState(String accessToken);
 

--- a/src/main/java/net/inpercima/runandfun/service/RunAndFunServiceImpl.java
+++ b/src/main/java/net/inpercima/runandfun/service/RunAndFunServiceImpl.java
@@ -138,6 +138,13 @@ public class RunAndFunServiceImpl implements RunAndFunService {
     }
 
     @Override
+    public Page<Activity> listAllActivitiesByType(String type) {
+        final int count = type != null ? repository.countByType(type) : (int) repository.count();
+        final Pageable pageable = new PageRequest(0, count);
+        return repository.findAllByTypeOrderByDateDesc(type, pageable);
+    }
+
+    @Override
     public Page<Activity> listActivities(final Pageable pageable, final String types, final LocalDate minDate, final LocalDate maxDate,
             final Float minDistance, final Float maxDistance, final String query) {
         final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();

--- a/src/main/java/net/inpercima/runandfun/web/RestApiController.java
+++ b/src/main/java/net/inpercima/runandfun/web/RestApiController.java
@@ -48,16 +48,21 @@ public class RestApiController {
         return appState;
     }
 
+    @RequestMapping(value = "/listActivitiesByType", method = RequestMethod.GET)
+    public Page<Activity> listActivitiesByType(@RequestParam(required = false) final String type) {
+        LOGGER.debug("listActivitiesByType '{}'", type);
+        return runAndFunService.listAllActivitiesByType(type);
+    }
+
     @RequestMapping(value = "/listActivities", method = RequestMethod.GET)
-    public Page<Activity> listActivities(
-            @PageableDefault(direction = Direction.DESC, sort = "date") final Pageable pageable,
+    public Page<Activity> listActivities(@PageableDefault(direction = Direction.DESC, sort = "date") final Pageable pageable,
             @RequestParam(required = false) final String type,
             @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) final LocalDate minDate,
             @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) final LocalDate maxDate,
-            @RequestParam(required = false) final Float minDistance,
-            @RequestParam(required = false) final Float maxDistance, @RequestParam(required = false) final String query) {
-        LOGGER.debug("listActivities of type '{}' for date between {} - {}, distance between {} - {}, {}", type,
-                minDate, maxDate, minDistance, maxDistance, pageable);
+            @RequestParam(required = false) final Float minDistance, @RequestParam(required = false) final Float maxDistance,
+            @RequestParam(required = false) final String query) {
+        LOGGER.debug("listActivities of type '{}' for date between {} - {}, distance between {} - {}, {}", type, minDate, maxDate,
+                minDistance, maxDistance, pageable);
         return runAndFunService.listActivities(pageable, type, minDate, maxDate, minDistance, maxDistance, query);
     }
 

--- a/src/main/resources/public/js/activity.service.js
+++ b/src/main/resources/public/js/activity.service.js
@@ -12,7 +12,11 @@
     this.recalculateTotals = recalculateTotals;
 
     function list(params) {
-      var url = '/listActivities' + addParams(params);
+      var url = '/listActivities';
+      if (params.size === -1) {
+        url += 'ByType';
+      }
+      url += addParams(params);
       $log.debug('activityService ' + url);
       return $http.get(url).then(function(result) {
         var activities = result.data;

--- a/src/main/resources/public/js/graphs.controller.js
+++ b/src/main/resources/public/js/graphs.controller.js
@@ -36,13 +36,15 @@
 
     function list() {
       loginService.state(vm);
-      // TODO set default maxSize of 500, later we need a list method that loads all activities at once
-      var maxSize = 500;
-      activityService.list(maxSize).then(function(data) {
+      var params = {
+        'size': -1
+      };
+      activityService.list(params).then(function(data) {
         vm.activities = data;
         getPieOverview(vm.activities.content);
       });
-      activityService.list(maxSize, 'Running').then(function(data) {
+      params.type = 'Running';
+      activityService.list(params).then(function(data) {
         vm.runs = data;
         refreshLineKmPerMonth();
       });

--- a/src/main/resources/public/partials/graphs.html
+++ b/src/main/resources/public/partials/graphs.html
@@ -3,7 +3,7 @@
 </div>
 <div>
   <h2>Distribution of activities</h2>
-  <p data-ng-cloak>All Activities: {{vm.activities.totalElements}}</p>
+  <p data-ng-cloak>All Activities: {{vm.activities.numberOfElements}}</p>
   <canvas id="pie" class="chart chart-pie"
     chart-data="vm.pieOverviewData" 
     chart-labels="vm.pieOverviewLabels"
@@ -18,7 +18,7 @@
       <option value="day">Day</option>
     </select> for running activities
   </h2>
-  <p data-ng-cloak>Running Activities: {{vm.runs.totalElements}}</p>
+  <p data-ng-cloak>Running Activities: {{vm.runs.numberOfElements}}</p>
   <canvas id="line" class="chart chart-line" 
     chart-data="vm.lineKmPerMonthData"
     chart-labels="vm.lineKmPerMonthLabels">

--- a/src/test/java/net/inpercima/runandfun/service/ActivityRepositoryTest.java
+++ b/src/test/java/net/inpercima/runandfun/service/ActivityRepositoryTest.java
@@ -1,11 +1,13 @@
 package net.inpercima.runandfun.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
 import net.inpercima.runandfun.Application;
 import net.inpercima.runandfun.model.Activity;
+import net.inpercima.runandfun.model.RunkeeperItem;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,5 +32,28 @@ public class ActivityRepositoryTest {
         final Page<Activity> page = repository.findAll(pageable);
         final List<Activity> content = page.getContent();
         assertEquals(1, content.size());
+    }
+
+    @Test
+    public void countAndfindAllByType() {
+        final int count = repository.countByType(RunkeeperItem.TYPE_RUNNING);
+        final Pageable pageable = new PageRequest(0, count);
+        final Page<Activity> page = repository.findAllByTypeOrderByDateDesc(RunkeeperItem.TYPE_RUNNING, pageable);
+        assertNotNull(page);
+        final List<Activity> content = page.getContent();
+        assertEquals(count, content.size());
+        content.stream().forEach(result -> {
+            assertEquals(RunkeeperItem.TYPE_RUNNING, result.getType());
+        });
+    }
+
+    @Test
+    public void countAndfindAllByTypeNull() {
+        final long count = repository.count();
+        final Pageable pageable = new PageRequest(0, (int) count);
+        final Page<Activity> page = repository.findAllByTypeOrderByDateDesc(null, pageable);
+        assertNotNull(page);
+        final List<Activity> content = page.getContent();
+        assertEquals(count, content.size());
     }
 }


### PR DESCRIPTION
* spring data elasticsearch findAll just returns the first 10 results
* according to https://jira.spring.io/browse/DATAES-58 it works as designed and is not subject to change
* workaround: first do a total count and set the result for the Pageable
* use -1 as an indicator for unlimited size
* use Page.numberOfElements instead of content.size within view