### PR TITLE
use ng-repeat and navbar-js-object combined with routeconfig

### DIFF
--- a/src/main/resources/public/js/navbar.directive.js
+++ b/src/main/resources/public/js/navbar.directive.js
@@ -2,11 +2,13 @@
   'use strict';
   angular.module('app').directive('navbar', function() {
     return {
-      controller : [ '$location', function($location) {
+      controller : [ '$location', 'navEntries', function($location, navEntries) {
         this.navClass = function(tabName) {
-          var currentRoute = $location.path().substring(1) || 'home';
+          var currentRoute = $location.path().substring(1);
           return currentRoute === tabName ? 'active' : '';
         };
+
+        this.navEntries = navEntries;
       } ],
       controllerAs : 'tab',
       restrict : 'E',

--- a/src/main/resources/public/js/route.provider.js
+++ b/src/main/resources/public/js/route.provider.js
@@ -1,24 +1,57 @@
 (function() {
   'use strict';
+  angular.module('app').constant('navEntries', [
+    {
+      controller: 'LoginController',
+      display: 'Home',
+      templateUrl: 'partials/home.html',
+      url: '',
+    },
+    {
+      controller: 'ActivityController',
+      display: 'Activities',
+      templateUrl: 'partials/activities.html',
+      url: 'activities',
+    },
+    {
+      controller: 'GraphsController',
+      controllerAs: 'vm',
+      display: 'Graphs',
+      templateUrl: 'partials/graphs.html',
+      url: 'graphs',
+    },
+  ]);
+
   angular.module('app').config(routeProvider);
 
-  routeProvider.$inject = [ '$routeProvider' ];
+  routeProvider.$inject = [ 'navEntries', '$routeProvider' ];
 
-  function routeProvider($routeProvider) {
-    $routeProvider.when('/', {
-      templateUrl: 'partials/home.html',
-      controller: 'LoginController',
-      controllerAs: 'vm'
-    }).when('/activities', {
-      templateUrl: 'partials/activities.html',
-      controller: 'ActivityController',
-      controllerAs: 'vm'
-    }).when('/graphs', {
-      templateUrl : 'partials/graphs.html',
-      controller: 'GraphsController',
-      controllerAs: 'vm'
-    }).otherwise({
+  function routeProvider(navEntries, $routeProvider) {
+    $routeProvider
+    .when(getUrl('LoginController', navEntries), getRouteConfig('LoginController', navEntries))
+    .when(getUrl('ActivityController', navEntries), getRouteConfig('ActivityController', navEntries))
+    .when(getUrl('GraphsController', navEntries), getRouteConfig('GraphsController', navEntries))
+    .otherwise({
       redirectTo: '/'
+    });
+  }
+
+  function getUrl(ctrl, entries) {
+    return '/' + entries[getIndex(ctrl, entries)].url;
+  }
+
+  function getRouteConfig(ctrl, entries) {
+    var i = getIndex(ctrl, entries);
+    return {
+      templateUrl: entries[i].templateUrl,
+      controller: entries[i].controller,
+      controllerAs: entries[i].controllerAs || 'vm',
+    };
+  }
+
+  function getIndex(ctrl, entries) {
+    return _.findIndex(entries, function(entry) {
+      return entry.controller === ctrl;
     });
   }
 })();

--- a/src/main/resources/public/partials/navbar.html
+++ b/src/main/resources/public/partials/navbar.html
@@ -1,8 +1,8 @@
 <nav>
   <div data-ng-transclude></div>
   <ul class="nav nav-tabs">
-    <li data-ng-class="tab.navClass('home')"><a href="#/">Home</a></li>
-    <li data-ng-class="tab.navClass('activities')"><a href="#/activities">Activities</a></li>
-    <li data-ng-class="tab.navClass('graphs')"><a href="#/graphs">Graphs</a></li>
+    <li ng-repeat="entry in tab.navEntries" data-ng-class="tab.navClass(entry.url)">
+      <a ng-href="#/{{entry.url}}" ng-bind="entry.display"></a>
+    </li>
   </ul>
 </nav>

--- a/src/main/resources/public/partials/navbar.html
+++ b/src/main/resources/public/partials/navbar.html
@@ -1,8 +1,8 @@
 <nav>
   <div data-ng-transclude></div>
   <ul class="nav nav-tabs">
-    <li ng-repeat="entry in tab.navEntries" data-ng-class="tab.navClass(entry.url)">
-      <a ng-href="#/{{entry.url}}" ng-bind="entry.display"></a>
+    <li data-ng-repeat="entry in tab.navEntries" data-ng-class="tab.navClass(entry.url)">
+      <a data-ng-href="#/{{entry.url}}" data-ng-bind="entry.display"></a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
Using ng-repeat to dynamically create the navbar within ```navbar.html```. With a given navbar constant its possible to adjust the routing and keep everything navbar related in one object. Therefore its easier to maintain and expand.

Some minor changes worth noting and discussing:
* removed the ``` || 'home'``` fallback for ```currentRoute```, since any unknown url redirects to ```'/'```
* removed the ```tab.navClass('home')``` and instead used ```tab.navClass('')```
* not sure how to format the navEntries-object
* keep navEntries-object in provider?
* controllerAs is optional when defining a new navEntry and defaults to ```'vm'```