### PR TITLE
Remove unnecessary and mistyped button style

### DIFF
--- a/src/main/resources/public/partials/graphs.html
+++ b/src/main/resources/public/partials/graphs.html
@@ -8,7 +8,7 @@
   <h2>
     Distribution of activities
 
-    <button type="button" class="btn btn-success" style="margin-eft: 10px" data-ng-click="vm.changeChartType()">Change Chart Type</button>
+    <button type="button" class="btn btn-success" data-ng-click="vm.changeChartType()">Change Chart Type</button>
   </h2>
   <p data-ng-cloak>All Activities: {{vm.activities.numberOfElements}}</p>
   <canvas id="pie" class="chart-base"


### PR DESCRIPTION
@inpercima there was a typo in `margin-left`. IMO the style is not needed at all.