### PR TITLE
Handling eslint warnings - fixes #77

### DIFF
--- a/src/main/resources/public/js/activity.service.js
+++ b/src/main/resources/public/js/activity.service.js
@@ -54,15 +54,15 @@
           addTimeForKm(activity, seconds, distanceHalfMarathon);
         }
         // calculate time for every distance starting with nearest km (round ceil)
-        for (let i = Math.ceil(activity.distance); i >= 1; i--) {
+        for (let km = Math.ceil(activity.distance); km >= 1; km--) {
           if (activity.additionalInfo.length > 0) {
             activity.additionalInfo += '\n';
           }
-          if (i === 21) {
+          if (km === 21) {
             addTimeForKm(activity, seconds, distanceHalfMarathon);
             activity.additionalInfo += '\n';
           }
-          addTimeForKm(activity, seconds, i);
+          addTimeForKm(activity, seconds, km);
         }
       });
     }
@@ -82,14 +82,14 @@
       }).sort((o1, o2) => {
         return o1.timePerKmInSeconds - o2.timePerKmInSeconds;
       });
-      let i = 0;
-      while (i < matches.length) {
-        if (activity.timePerKmInSeconds <= matches[i].timePerKmInSeconds) {
+      let item = 0;
+      while (item < matches.length) {
+        if (activity.timePerKmInSeconds <= matches[item].timePerKmInSeconds) {
           break;
         }
-        i += 1;
+        item += 1;
       }
-      activity.intervalStats = `Platz ${i} von ${matches.length} zwischen ${minDistance} und ${maxDistance} km`;
+      activity.intervalStats = `Platz ${item} von ${matches.length} zwischen ${minDistance} und ${maxDistance} km`;
     }
 
     function addTimeForKm(activity, totalSeconds, distance) {
@@ -104,8 +104,8 @@
     function getTotalDistance(activities) {
       logger.debug('getTotalDistance');
       let sum = 0;
-      for (let i = 0; i < activities.length; i++) {
-        sum += activities[i].distance;
+      for (let item = 0; item < activities.length; item++) {
+        sum += activities[item].distance;
       }
       return sum.toFixed(2);
     }
@@ -113,8 +113,8 @@
     function getTotalTime(activities) {
       logger.debug('getTotalTime');
       let sum = 0;
-      for (let i = 0; i < activities.length; i++) {
-        sum += dateTimeUtils.formattedTimeToSeconds(activities[i].duration);
+      for (let item = 0; item < activities.length; item++) {
+        sum += dateTimeUtils.formattedTimeToSeconds(activities[item].duration);
       }
       return sum;
     }

--- a/src/main/resources/public/js/date.time.utils.js
+++ b/src/main/resources/public/js/date.time.utils.js
@@ -28,6 +28,8 @@
     }
 
     function getTimePart(part) {
+      // it is better readable with nested-ternary so it will be disabled from check
+      // eslint-disable-next-line no-nested-ternary
       return part < 1 ? '00' : (part < 10 ? `0${part}` : part);
     }
   }

--- a/src/main/resources/public/js/graphs.controller.js
+++ b/src/main/resources/public/js/graphs.controller.js
@@ -85,9 +85,9 @@
         }
       }
 
-      for (let i = 0, len = sortedActivities.length; i < len; i++) {
-        const readableDateLong = utilService.dateFilter(sortedActivities[i].date).split(DASH);
-        const readableDateShort = utilService.dateFilter(sortedActivities[i].date).split(DASH);
+      for (let item = 0, len = sortedActivities.length; item < len; item++) {
+        const readableDateLong = utilService.dateFilter(sortedActivities[item].date).split(DASH);
+        const readableDateShort = utilService.dateFilter(sortedActivities[item].date).split(DASH);
 
         let label;
         let groupByKey;
@@ -109,12 +109,13 @@
             groupByKey = label + DOT + readableDateShort[0];
           }
         }
-        const distance = parseFloat(sortedActivities[i].distance.toFixed(2, 2));
+        const distance = parseFloat(sortedActivities[item].distance.toFixed(2, 2));
 
         data[groupByKey] = data[groupByKey] + distance || distance;
         labels[groupByKey] = labels[groupByKey] = label;
 
-        if (i + 1 === len || year && year !== utilService.dateFilter(sortedActivities[i + 1].date).split(DASH)[0]) {
+        if (item + 1 === len || year && year !== utilService.dateFilter(sortedActivities[item + 1].date)
+            .split(DASH)[0]) {
           logger.debug('end of series');
 
           const series = [];

--- a/src/main/resources/public/js/log.config.js
+++ b/src/main/resources/public/js/log.config.js
@@ -23,6 +23,8 @@
 
       function enhanceLogging(logger, className, logText) {
         return function() {
+          // the next line cannot be simply refactored so it will be disabled from check
+          // eslint-disable-next-line prefer-rest-params
           const args = [].slice.call(arguments);
           const logging = `${new Date().toString()} [${logText}] ${className}: ${args[0]}`;
           // add new message to the original debug method

--- a/src/main/resources/public/js/util.service.js
+++ b/src/main/resources/public/js/util.service.js
@@ -32,8 +32,8 @@
 
     service.listYears = function(firstEntry) {
       const result = [firstEntry];
-      for (let i = 2010; i <= new Date().getFullYear(); i++) {
-        result.push(service.simpleKeyYear(i));
+      for (let year = 2010; year <= new Date().getFullYear(); year++) {
+        result.push(service.simpleKeyYear(year));
       }
       return result;
     };


### PR DESCRIPTION
* define some more intuitive names of variables
* disable one line from check (prefer-rest-params)
* fix no-nested-ternary