### PR TITLE
Update gradle-node-plugin to 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,7 @@ buildscript {
 }
 
 plugins {
-  id "com.moowork.grunt" version "0.13"
-  id "com.moowork.node" version "0.13"
+  id "com.moowork.grunt" version "1.1.1"
 }
 
 apply plugin: "java"


### PR DESCRIPTION
"The plugin will also automatically apply the Node Plugin" according to https://github.com/srs/gradle-node-plugin/blob/master/docs/grunt.md

Therefore, we just need com.moowork.grunt